### PR TITLE
Fix useless building cabal-install from source.

### DIFF
--- a/haskell-cabal2nix/flake.nix
+++ b/haskell-cabal2nix/flake.nix
@@ -31,8 +31,8 @@
         defaultPackage = self.packages.${system}.${packageName};
 
         devShell = pkgs.mkShell {
-          buildInputs = with haskellPackages; [
-            haskell-language-server
+          buildInputs = with pkgs; [
+            haskellPackages.haskell-language-server # you must build it with your ghc to work
             ghcid
             cabal-install
           ];


### PR DESCRIPTION
Hello! I founded, that you fetch cabal-install from haskellPackages and then build in from source, but it's not necessary.