### PR TITLE
Add github ci configuration for new haskell projects

### DIFF
--- a/haskell.nix/.github/workflows/check.yml
+++ b/haskell.nix/.github/workflows/check.yml
@@ -1,0 +1,11 @@
+name: Nix flake check
+on: push
+
+jobs:
+  check:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: check nix flake
+        run: nix flake check -L

--- a/haskell.nix/flake.nix
+++ b/haskell.nix/flake.nix
@@ -24,11 +24,7 @@
     ##};
   };
 
-  outputs = { self, nixpkgs, haskell-nix, hackage, stackage, serokell-nix, flake-compat }:
-
-  # for weeder:
-  ##outputs = { self, nixpkgs, haskell-nix, hackage, stackage, flake-compat, serokell-nix, haskell-nix-weeder }:
-
+  outputs = { self, nixpkgs, haskell-nix, hackage, stackage, serokell-nix, flake-compat, ... }@inputs:
     let
       pkgs = nixpkgs.legacyPackages.x86_64-linux.extend
           (nixpkgs.lib.composeManyExtensions [ serokell-nix.overlay ]);
@@ -81,7 +77,7 @@
       all-components = get-package-components hs-pkg.components;
 
       # for weeder:
-      ##weeder-hacks = import haskell-nix-weeder { inherit pkgs; };
+      ##weeder-hacks = import inputs.haskell-nix-weeder { inherit pkgs; };
 
       # nixpkgs has weeder 2, but we use weeder 1
       ##weeder-legacy = pkgs.haskellPackages.callHackageDirect {


### PR DESCRIPTION
This pr adds a template github ci configuration for new haskell projects.

It should be noted that since the github workflow runs on `self-hosted` it will only work in the `serokell` organization or in other namespaces that have self-hosted github-runners set up.