### PR TITLE
Unify haskell.nix CI templates

### DIFF
--- a/haskell.nix/.buildkite/pipeline.yml
+++ b/haskell.nix/.buildkite/pipeline.yml
@@ -1,5 +1,25 @@
 steps:
 
+- label: xrefcheck
+  commands:
+  - nix run github:serokell/xrefcheck
+
+- label: reuse
+  commands:
+  - nix build -L .#checks.x86_64-linux.reuse-lint
+
+- label: hlint
+  commands:
+  - nix build -L .#checks.x86_64-linux.hlint
+
+- label: stylish-haskell
+  commands:
+  - nix build -L .#checks.x86_64-linux.stylish-haskell
+
+- label: check-trailing-whitespace
+  commands:
+  - nix build -L .#checks.x86_64-linux.trailing-whitespace
+
 # build haskell components
 - label: build
   commands:
@@ -12,17 +32,3 @@ steps:
 - label: test
   commands:
   - nix-build -A checks.x86_64-linux.test
-
-# run hlint
-##- label: hlint
-##  commands:
-##  - nix run -f. legacyPackages.x86_64-linux.haskellPackages.hlint
-##      -c hlint -j --hint .hlint.yaml */
-
-# run weeder
-##- label: weeder
-##  commands:
-##  - nix-build -A weeder-script
-##    # weeder needs .cabal file:
-##  - nix run -f. legacyPackages.x86_64-linux.haskellPackages.hpack -c hpack
-##  - ./result

--- a/haskell.nix/.github/workflows/check.yml
+++ b/haskell.nix/.github/workflows/check.yml
@@ -2,10 +2,44 @@ name: Nix flake check
 on: push
 
 jobs:
-  check:
+  validate:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
 
-      - name: check nix flake
-        run: nix flake check -L
+      - name: xrefcheck
+        run: nix run github:serokell/xrefcheck
+
+      - name: reuse
+        run: nix build -L .#checks.x86_64-linux.reuse-lint
+        # Run step even if the previous one has failed
+        if: success() || failure()
+
+      - name: hlint
+        run: nix build -L .#checks.x86_64-linux.hlint
+        if: success() || failure()
+
+      - name: stylish-haskell
+        run: nix build -L .#checks.x86_64-linux.stylish-haskell
+        if: success() || failure()
+
+      - name: check-trailing-whitespace
+        run: nix build -L .#checks.x86_64-linux.trailing-whitespace
+        if: success() || failure()
+
+  build:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: build-all
+        run: nix build -L .#checks.x86_64-linux.build-all
+
+  test:
+    runs-on: self-hosted
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: test
+        run: nix build -L .#checks.x86_64-linux.test

--- a/haskell.nix/.gitlab-ci.yml
+++ b/haskell.nix/.gitlab-ci.yml
@@ -3,33 +3,43 @@ default:
   tags: [nix]
 
 stages:
+  - validate
   - build
   - test
+
+xrefcheck:
+  stage: validate
+  script:
+    - nix run github:serokell/xrefcheck
+
+reuse:
+  stage: validate
+  script:
+    - nix build -L .#checks.x86_64-linux.reuse-lint
+
+hlint:
+  stage: validate
+  script:
+    - nix build -L .#checks.x86_64-linux.hlint
+
+stylish-haskell:
+  stage: validate
+  script:
+    - nix build -L .#checks.x86_64-linux.stylish-haskell
+
+check-trailing-whitespace:
+  stage: validate
+  script:
+    - nix build -L .#checks.x86_64-linux.trailing-whitespace
 
 # build haskell components
 build-all:
   stage: build
   script:
-  - nix-build -A checks.x86_64-linux.build-all
+  - nix build -L .#checks.x86_64-linux.build-all
 
 # run the tests
 test:
   stage: test
   script:
-  - nix-build -A checks.x86_64-linux.test
-
-# run hlint
-##hlint:
-##  stage: test
-##  script:
-##  - nix run -f. legacyPackages.x86_64-linux.haskellPackages.hlint
-##      -c hlint --hint .hlint.yaml */
-
-# run weeder
-##weeder:
-##  stage: test
-##  script:
-##  - nix-build -A weeder-script
-##    # weeder needs .cabal file:
-##  - nix run -f. legacyPackages.x86_64-linux.haskellPackages.hpack -c hpack
-##  - ./result
+  - nix build -L .#checks.x86_64-linux.test

--- a/haskell.nix/flake.nix
+++ b/haskell.nix/flake.nix
@@ -4,7 +4,7 @@
   };
 
   inputs = {
-    flake-utils = "github:numtide/flake-utils";
+    flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
       flake = false;
     };


### PR DESCRIPTION
Problem: Currently CI pipeline templates for GA, GitLab CI, and Buildkite
are quite different. Some of these templates miss some steps.

Solution: Unify these templates. Introduce a single step for each
flake check. Such verbosity will be easier for developers than a single
'nix flake check' invocation.