### PR TITLE
[OPS-958] Add hpack and stack2cabal checks

### DIFF
--- a/haskell.nix/README.md
+++ b/haskell.nix/README.md
@@ -55,4 +55,8 @@ Haskell application and library templates for Buildkite, Gitlab or GitHub CI usi
 
     2. If your project contains bash scripts, uncomment related lines in `flake.nix` and in the pipeline configuration. If you don't need `shellcheck`, remove those lines.
 
+    3. If you're using `hpack` or `stack2cabal` in your project, make sure to uncomment the related lines in both `flake.nix` and pipeline configuration files. To avoid version mismatches, use `nix develop .#ci -c hpack` or `nix develop .#ci -c stack2cabal`.
+
+    4. Make sure to clean up your `flake.nix` and pipeline configuration files by removing any optional code that is left commented out.
+
 - Enjoy working CI!

--- a/haskell.nix/application/.buildkite/pipeline.yml
+++ b/haskell.nix/application/.buildkite/pipeline.yml
@@ -20,6 +20,14 @@ steps:
   commands:
   - nix build -L .#checks.x86_64-linux.trailing-whitespace
 
+# - label: check-stack2cabal
+#   commands:
+#   - nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
+
+# - label: check-hpack
+#   commands:
+#   - nix build -L .#checks.x86_64-linux.hpack
+
 # build haskell components
 - label: build
   commands:

--- a/haskell.nix/application/.github/workflows/check.yml
+++ b/haskell.nix/application/.github/workflows/check.yml
@@ -27,6 +27,14 @@ jobs:
         run: nix build -L .#checks.x86_64-linux.trailing-whitespace
         if: success() || failure()
 
+      # - name: check-stack2cabal
+      #   run: nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
+      #   if: success() || failure()
+
+      # - name: check-hpack
+      #   run: nix build -L .#checks.x86_64-linux.hpack
+      #   if: success() || failure()
+
   build:
     runs-on: [self-hosted, nix]
     steps:

--- a/haskell.nix/application/.gitlab-ci.yml
+++ b/haskell.nix/application/.gitlab-ci.yml
@@ -32,6 +32,16 @@ check-trailing-whitespace:
   script:
     - nix build -L .#checks.x86_64-linux.trailing-whitespace
 
+# check-stack2cabal:
+#   stage: validate
+#   script:
+#     - nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
+
+# check-hpack:
+#   stage: validate
+#   script:
+#     - nix build -L .#checks.x86_64-linux.hpack
+
 # build haskell components
 build-all:
   stage: build

--- a/haskell.nix/application/flake.nix
+++ b/haskell.nix/application/flake.nix
@@ -72,9 +72,24 @@
       # all components for the current haskell package
       all-components = get-package-components hs-pkg.components;
 
+      # Uncomment if your project uses stack2cabal to generate cabal files
+      # stack2cabal = haskellPkgs.haskell.lib.overrideCabal haskellPkgs.haskellPackages.stack2cabal
+      # (drv: { jailbreak = true; broken = false; });
+
     in {
       # nixpkgs revision pinned by this flake
       legacyPackages = pkgs;
+
+      # Uncomment if your project uses hpack or stack2cabal to update cabal files, remove the one you don't use
+      # To avoid version mismatches, use `nix develop .#ci -c hpack` or `nix develop .#ci -c stack2cabal`
+      # devShell = {
+      #   ci = pkgs.mkShell {
+      #     buildInputs = [
+      #       pkgs.hpack
+      #       stack2cabal
+      #     ];
+      #   };
+      # };
 
       # derivations that we can run from CI
       checks = {
@@ -91,6 +106,8 @@
 
         hlint = pkgs.build.haskell.hlint ./.;
         stylish-haskell = pkgs.build.haskell.stylish-haskell ./.;
+        # Uncomment if your project uses hpack to generate cabal files
+        # hpack = pkgs.build.haskell.hpack ./.;
       };
     });
 }

--- a/haskell.nix/library/.buildkite/pipeline.yml
+++ b/haskell.nix/library/.buildkite/pipeline.yml
@@ -24,6 +24,14 @@ steps:
 #   commands:
 #   - nix build -L .#checks.x86_64-linux.shellcheck
 
+# - label: check-stack2cabal
+#   commands:
+#   - nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
+
+# - label: check-hpack
+#   commands:
+#   - nix build -L .#checks.x86_64-linux.hpack
+
 # build haskell components
 - group: build
   steps:

--- a/haskell.nix/library/.github/workflows/check.yml
+++ b/haskell.nix/library/.github/workflows/check.yml
@@ -27,6 +27,14 @@ jobs:
         run: nix build -L .#checks.x86_64-linux.trailing-whitespace
         if: success() || failure()
 
+      # - name: check-stack2cabal
+      #   run: nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
+      #   if: success() || failure()
+
+      # - name: check-hpack
+      #   run: nix build -L .#checks.x86_64-linux.hpack
+      #   if: success() || failure()
+
       # - name: shellcheck
       #   run: nix build -L .#checks.x86_64-linux.shellcheck
       #   if: success() || failure()

--- a/haskell.nix/library/.gitlab-ci.yml
+++ b/haskell.nix/library/.gitlab-ci.yml
@@ -37,6 +37,16 @@ check-trailing-whitespace:
 #   script:
 #     - nix build -L .#checks.x86_64-linux.shellcheck
 
+# check-stack2cabal:
+#   stage: validate
+#   script:
+#     - nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
+
+# check-hpack:
+#   stage: validate
+#   script:
+#     - nix build -L .#checks.x86_64-linux.hpack
+
 # build haskell components
 build-all:
   stage: build

--- a/haskell.nix/library/flake.nix
+++ b/haskell.nix/library/flake.nix
@@ -85,6 +85,11 @@
               (lib.attrValues pkg.${hs-package-name}.checks);
             in lib.nameValuePair "${ghc}:test-all"
               (pkgs.linkFarmFromDrvs "test-all" tests)) pkgs-per-ghc;
+
+        # Uncomment if your project uses stack2cabal to generate cabal files
+        # stack2cabal = haskellPkgs.haskell.lib.overrideCabal haskellPkgs.haskellPackages.stack2cabal
+        # (drv: { jailbreak = true; broken = false; });
+
       in {
         # nixpkgs revision pinned by this flake
         legacyPackages = pkgs;
@@ -92,6 +97,17 @@
         # Uncomment if your project uses GitHub actions
         # ghc-matrix = {
         #   include = map (ver: { ghc = ver; }) ghc-versions;
+        # };
+
+        # Uncomment if your project uses hpack or stack2cabal to update cabal files, remove the one you don't use
+        # To avoid version mismatches, use `nix develop .#ci -c hpack` or `nix develop .#ci -c stack2cabal`
+        # devShell = {
+        #   ci = pkgs.mkShell {
+        #     buildInputs = [
+        #       pkgs.hpack
+        #       stack2cabal
+        #     ];
+        #   };
         # };
 
         # derivations that we can run from CI
@@ -104,6 +120,8 @@
 
           hlint = pkgs.build.haskell.hlint ./.;
           stylish-haskell = pkgs.build.haskell.stylish-haskell ./.;
+          # Uncomment if your project uses hpack to generate cabal files
+          # hpack = pkgs.build.haskell.hpack ./.;
         };
       });
 }


### PR DESCRIPTION
Problem: We need to be able to check if our cabal files generated with hpack and stack2cabal are up to date.

Solution: Add hpack and stack2cabal checks.