### PR TITLE
[OPS-1468] Read GHC versions from `.cabal` file

### DIFF
--- a/haskell.nix/README.md
+++ b/haskell.nix/README.md
@@ -16,7 +16,7 @@ Haskell application and library templates for Buildkite, Gitlab or GitHub CI usi
 
     1.
        - **FOR APPLICATION:** Replace `pataq-package` in `flake.nix` with your haskell package name (usually specified in `package.yaml`). And replace `pataq-test` at the bottom of `flake.nix` with the name of the test component in your package.
-       - **FOR LIBRARY:** Replace `pataq-package` in `flake.nix` with your haskell library name (usually specified in `package.yaml`). Then change `ghc-versions` in `flake.nix` to the list of GHC versions that will be used to build and test your library. If you are using GitHub actions, uncomment `ghc-matrix` in `flake.nix`, otherwise change `matrix` in the CI pipeline to the list of GHC versions specified in `ghc-versions`.
+       - **FOR LIBRARY:** Replace `pataq-package` in `flake.nix` with your haskell library name (usually specified in `package.yaml`). Then list the GHC versions that will be used to build and test your library in the [`tested-with`](https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-tested-with) stanza of the `.cabal` file and change `./pataq-package.cabal` in `ghc-versions` in `flake.nix` to the path to your `.cabal` file. If you are using GitHub actions, uncomment `ghc-matrix` in `flake.nix`, otherwise change `matrix` in the CI pipeline to the list of GHC versions specified in `ghc-versions`.
     If your project contains multiple packages, you need to make the following changes to `flake.nix`:
             * Replace `hs-package-name` with a list of package names (note the "s" at the end of the attribute name):
             ```nix

--- a/haskell.nix/library/.github/workflows/check.yml
+++ b/haskell.nix/library/.github/workflows/check.yml
@@ -55,8 +55,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: build
-        run: nix build -L .#checks.x86_64-linux.ghc${{ matrix.ghc }}:build-all --keep-going
+        run: nix build -L .#checks.x86_64-linux.${{ matrix.ghc }}:build-all --keep-going
 
       - name: test
-        run: nix build -L .#checks.x86_64-linux.ghc${{ matrix.ghc }}:test-all --keep-going
+        run: nix build -L .#checks.x86_64-linux.${{ matrix.ghc }}:test-all --keep-going
         if: success() || failure()

--- a/haskell.nix/library/flake.nix
+++ b/haskell.nix/library/flake.nix
@@ -24,6 +24,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         haskellPkgs = haskell-nix.legacyPackages."${system}";
+        inherit (serokell-nix.lib) cabal;
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
@@ -35,10 +36,10 @@
 
         hs-package-name = "pataq-package";
 
-        ghc-versions = [ "884" "8107" "902" ];
+        ghc-versions = cabal.getTestedWithVersions ./pataq-package.cabal;
 
         # invoke haskell.nix for each ghc version listed in ghc-versions
-        pkgs-per-ghc = lib.genAttrs (map (v: "ghc${v}") ghc-versions)
+        pkgs-per-ghc = lib.genAttrs ghc-versions
           (ghc: haskellPkgs.haskell-nix.cabalProject {
             src = haskellPkgs.haskell-nix.haskellLib.cleanGit {
               name = hs-package-name;


### PR DESCRIPTION
Problem: We have a CI template for libraries which suggests specifying it in ghc-versions. So if we use this template and specify tested-with, we duplicate this information. Specifying it in tested-with seems better, because this is a more standardized way and is more accessible by users of the package.

Solution: Read GHC versions from `.cabal` file.

Related PR: https://github.com/serokell/serokell.nix/pull/129