### PR TITLE
[OPS-1477] Add cabal check

### DIFF
--- a/haskell.nix/application/.github/workflows/check.yml
+++ b/haskell.nix/application/.github/workflows/check.yml
@@ -27,6 +27,10 @@ jobs:
         run: nix build -L .#checks.x86_64-linux.trailing-whitespace
         if: success() || failure()
 
+      # - name: cabal-check
+      #   run: nix build -L .#checks.x86_64-linux.cabal-check
+      #   if: success() || failure()
+
       # - name: check-stack2cabal
       #   run: nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
       #   if: success() || failure()

--- a/haskell.nix/application/.gitlab-ci.yml
+++ b/haskell.nix/application/.gitlab-ci.yml
@@ -32,6 +32,11 @@ check-trailing-whitespace:
   script:
     - nix build -L .#checks.x86_64-linux.trailing-whitespace
 
+# cabal-check:
+#   stage: validate
+#   script:
+#     - nix build -L .#checks.x86_64-linux.cabal-check
+
 # check-stack2cabal:
 #   stage: validate
 #   script:

--- a/haskell.nix/application/flake.nix
+++ b/haskell.nix/application/flake.nix
@@ -106,6 +106,8 @@
 
         hlint = pkgs.build.haskell.hlint ./.;
         stylish-haskell = pkgs.build.haskell.stylish-haskell ./.;
+        # Uncomment if your project is published on hackage
+        # cabal-check = pkgs.build.haskell.cabal-check ./.;
         # Uncomment if your project uses hpack to generate cabal files
         # hpack = pkgs.build.haskell.hpack ./.;
       };

--- a/haskell.nix/library/.github/workflows/check.yml
+++ b/haskell.nix/library/.github/workflows/check.yml
@@ -27,6 +27,10 @@ jobs:
         run: nix build -L .#checks.x86_64-linux.trailing-whitespace
         if: success() || failure()
 
+      - name: cabal-check
+        run: nix build -L .#checks.x86_64-linux.cabal-check
+        if: success() || failure()
+
       # - name: check-stack2cabal
       #   run: nix develop .#ci -c bash -c 'stack2cabal && git add -A && git diff HEAD --exit-code'
       #   if: success() || failure()

--- a/haskell.nix/library/.gitlab-ci.yml
+++ b/haskell.nix/library/.gitlab-ci.yml
@@ -32,6 +32,11 @@ check-trailing-whitespace:
   script:
     - nix build -L .#checks.x86_64-linux.trailing-whitespace
 
+cabal-check:
+  stage: validate
+  script:
+    - nix build -L .#checks.x86_64-linux.cabal-check
+
 # shellcheck:
 #   stage: validate
 #   script:

--- a/haskell.nix/library/flake.nix
+++ b/haskell.nix/library/flake.nix
@@ -121,6 +121,7 @@
 
           hlint = pkgs.build.haskell.hlint ./.;
           stylish-haskell = pkgs.build.haskell.stylish-haskell ./.;
+          cabal-check = pkgs.build.haskell.cabal-check ./.;
           # Uncomment if your project uses hpack to generate cabal files
           # hpack = pkgs.build.haskell.hpack ./.;
         };


### PR DESCRIPTION
Problem: In order to publish a package to hackage, it must meet certain requirements, which can be verified using cabal check. Since we want to publish our packages to hackage, it makes sense to add a cabal check step to the CI pipelines of our haskell.nix templates.

Solution: Add cabal check.