### PR TITLE
[Chore] Document how to set up a haskell project root folder

### DIFF
--- a/haskell.nix/README.md
+++ b/haskell.nix/README.md
@@ -14,9 +14,9 @@ Haskell application and library templates for Buildkite, Gitlab or GitHub CI usi
 
 - Afterwards, adjust the template for your project:
 
-    1.
-       - **FOR APPLICATION:** Replace `pataq-package` in `flake.nix` with your haskell package name (usually specified in `package.yaml`). And replace `pataq-test` at the bottom of `flake.nix` with the name of the test component in your package.
-       - **FOR LIBRARY:** Replace `pataq-package` in `flake.nix` with your haskell library name (usually specified in `package.yaml`). Then list the GHC versions that will be used to build and test your library in the [`tested-with`](https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-tested-with) stanza of the `.cabal` file and change `./pataq-package.cabal` in `ghc-versions` in `flake.nix` to the path to your `.cabal` file. If you are using GitHub actions, uncomment `ghc-matrix` in `flake.nix`, otherwise change `matrix` in the CI pipeline to the list of GHC versions specified in `ghc-versions`.
+    1. Replace `pataq-package` in `flake.nix` with your haskell package name (usually specified in `package.yaml`). If the root of your haskell project (directory containing `stack.yaml` or `cabal.project`) is not the same as the directory where `flake.nix` is ​​located, you need to set `src = ./.;` from `flake.nix` to the root of your haskell project.
+       - **FOR APPLICATION:**  Replace `pataq-test` at the bottom of `flake.nix` with the name of the test component in your package.
+       - **FOR LIBRARY:** List the GHC versions that will be used to build and test your library in the [`tested-with`](https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-tested-with) stanza of the `.cabal` file and change `./pataq-package.cabal` in `ghc-versions` in `flake.nix` to the path to your `.cabal` file. If you are using GitHub actions, uncomment `ghc-matrix` in `flake.nix`, otherwise change `matrix` in the CI pipeline to the list of GHC versions specified in `ghc-versions`.
     If your project contains multiple packages, you need to make the following changes to `flake.nix`:
             * Replace `hs-package-name` with a list of package names (note the "s" at the end of the attribute name):
             ```nix

--- a/haskell.nix/application/flake.nix
+++ b/haskell.nix/application/flake.nix
@@ -39,6 +39,7 @@
       hs-pkgs = haskellPkgs.haskell-nix.stackProject {
         src = haskellPkgs.haskell-nix.haskellLib.cleanGit {
           name = hs-package-name;
+          # specify the path to the root of your haskell project (the directory containing stack.yaml or cabal.project)
           src = ./.;
         };
 

--- a/haskell.nix/library/flake.nix
+++ b/haskell.nix/library/flake.nix
@@ -43,6 +43,7 @@
           (ghc: haskellPkgs.haskell-nix.cabalProject {
             src = haskellPkgs.haskell-nix.haskellLib.cleanGit {
               name = hs-package-name;
+              # specify the path to the root of your haskell project (the directory containing stack.yaml or cabal.project)
               src = ./.;
             };
             compiler-nix-name = ghc;


### PR DESCRIPTION
Problem: The template currently assumes that the haskell project root is in the same directory as flake.nix, but this is not always the case. We need to document how to set up a different path to the haskell project root.

Solution: Document how to set up a haskell project root folder in flake.nix.