### PR TITLE
[OPS-1458] Use `makeCI` wrapper

### DIFF
--- a/haskell.nix/README.md
+++ b/haskell.nix/README.md
@@ -14,44 +14,8 @@ Haskell application and library templates for Buildkite, Gitlab or GitHub CI usi
 
 - Afterwards, adjust the template for your project:
 
-    1. Replace `pataq-package` in `flake.nix` with your haskell package name (usually specified in `package.yaml`). If the root of your haskell project (directory containing `stack.yaml` or `cabal.project`) is not the same as the directory where `flake.nix` is ​​located, you need to set `src = ./.;` from `flake.nix` to the root of your haskell project.
-       - **FOR APPLICATION:**  Replace `pataq-test` at the bottom of `flake.nix` with the name of the test component in your package.
-       - **FOR LIBRARY:** List the GHC versions that will be used to build and test your library in the [`tested-with`](https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-tested-with) stanza of the `.cabal` file and change `./pataq-package.cabal` in `ghc-versions` in `flake.nix` to the path to your `.cabal` file. If you are using GitHub actions, uncomment `ghc-matrix` in `flake.nix`, otherwise change `matrix` in the CI pipeline to the list of GHC versions specified in `ghc-versions`.
-    If your project contains multiple packages, you need to make the following changes to `flake.nix`:
-            * Replace `hs-package-name` with a list of package names (note the "s" at the end of the attribute name):
-            ```nix
-            hs-package-names = [ "first-package-name" "second-package-name" ];
-            ```
-            * Update `modules`, `build-all`, and `test-all` to map over all packages as follows:
-
-            ```nix
-            modules = map (hs-package-name: {
-              packages.${hs-package-name} = {
-                ghcOptions = [
-                  "-Werror"
-                  "-O0"
-                ];
-              };
-            }) hs-package-names;
-            ```
-
-            ```nix
-            build-all = lib.mapAttrs'
-              (ghc: pkg:
-                let components = lib.concatMap (hs-package-name:
-                  get-package-components pkg.${hs-package-name}.components) hs-package-names;
-                in lib.nameValuePair "${ghc}:build-all"
-                  (pkgs.linkFarmFromDrvs "build-all" components)) pkgs-per-ghc;
-            ```
-
-            ```nix
-            test-all = lib.mapAttrs'
-              (ghc: pkg:
-                let tests = lib.concatMap (hs-package-name: lib.filter lib.isDerivation
-                  (lib.attrValues pkg.${hs-package-name}.checks)) hs-package-names;
-                in lib.nameValuePair "${ghc}:test-all"
-                  (pkgs.linkFarmFromDrvs "test-all" tests)) pkgs-per-ghc;
-            ```
+    1. If the root of your haskell project (directory containing `stack.yaml` or `cabal.project`) is not the same as the directory where `flake.nix` is ​​located, you need to set `src = ./.;` from `flake.nix` to the root of your haskell project.
+       - **FOR LIBRARY:** List the GHC versions that will be used to build and test your library in the [`tested-with`](https://cabal.readthedocs.io/en/3.4/cabal-package.html#pkg-field-tested-with) stanza of the `.cabal` files, alternatively you can set them with the `ghcVersions` argument. If your project contains multiple `stack.yaml` files, or if you want to test your library with different stack resolvers, you can set them in `stackFiles` and `resolvers` respectively. If you are using GitHub actions, uncomment `inherit (ci) build-matrix` in `flake.nix`, otherwise change `matrix` in the CI pipeline to the list of GHC versions, `stack.yaml` files, and resolvers.
 
     2. If your project contains bash scripts, uncomment related lines in `flake.nix` and in the pipeline configuration. If you don't need `shellcheck`, remove those lines.
 

--- a/haskell.nix/application/flake.nix
+++ b/haskell.nix/application/flake.nix
@@ -33,45 +33,25 @@
 
       lib = pkgs.lib;
 
-      hs-package-name = "pataq-package";
-
       # invoke haskell.nix
       hs-pkgs = haskellPkgs.haskell-nix.stackProject {
         src = haskellPkgs.haskell-nix.haskellLib.cleanGit {
-          name = hs-package-name;
           # specify the path to the root of your haskell project (the directory containing stack.yaml or cabal.project)
           src = ./.;
         };
 
         # haskell.nix configuration
-        modules = [{
-          packages.${hs-package-name} = {
+        modules = [
+          (serokell-nix.lib.haskell.optionsLocalPackages {
             ghcOptions = [
               # fail on warnings
               "-Werror"
               # disable optimisations, we don't need them if we don't package or deploy the executable
               "-O0"
             ];
-          };
-
-        }];
+          })
+        ];
       };
-
-      hs-pkg = hs-pkgs.${hs-package-name};
-
-      # returns the list of all components for a package
-      get-package-components = pkg:
-        # library
-        lib.optional (pkg ? library) pkg.library
-        # haddock
-        ++ lib.optional (pkg ? library) pkg.library.haddock
-        # exes, tests and benchmarks
-        ++ lib.attrValues pkg.exes
-        ++ lib.attrValues pkg.tests
-        ++ lib.attrValues pkg.benchmarks;
-
-      # all components for the current haskell package
-      all-components = get-package-components hs-pkg.components;
 
       # Uncomment if your project uses stack2cabal to generate cabal files
       # stack2cabal = haskellPkgs.haskell.lib.overrideCabal haskellPkgs.haskellPackages.stack2cabal
@@ -95,10 +75,10 @@
       # derivations that we can run from CI
       checks = {
         # builds all haskell components
-        build-all = pkgs.linkFarmFromDrvs "build-all" all-components;
+        build-all = pkgs.linkFarmFromDrvs "build-all" (lib.attrValues hs-pkgs.flake'.packages);
 
         # runs the test
-        test = hs-pkg.checks.pataq-test;
+        test = pkgs.linkFarmFromDrvs "test-all" (lib.attrValues hs-pkgs.flake'.checks);
 
         trailing-whitespace = pkgs.build.checkTrailingWhitespace ./.;
         reuse-lint = pkgs.build.reuseLint ./.;

--- a/haskell.nix/library/.buildkite/pipeline.yml
+++ b/haskell.nix/library/.buildkite/pipeline.yml
@@ -35,14 +35,21 @@ steps:
 # build haskell components
 - group: build
   steps:
-    - label: ghc{{matrix}}
-      command: nix build -L .#checks.x86_64-linux.ghc${{ matrix }}:build-all --keep-going
+    - label: {{matrix}}
+      command: nix build -L .#checks.x86_64-linux.${{ matrix }}:build-all --keep-going
 
-      # list of GHC versions must be in sync with ghc-versions from flake.nix
-      matrix: &ghc-matrix
-        - "884"
-        - "8107"
-        - "902"
+      # list of check prefixes for haskell components
+      matrix: &build-matrix
+        # ghc versions
+        - "ghc884"
+        - "ghc8107"
+        - "ghc902"
+        # stack files and resolvers
+        # NOTE: all dots should be replaced with dashes
+        - "stack-yaml"
+        - "stack-lts-21-5-yaml"
+        - "lts-19-13"
+
 
 # don't run tests until all components are built
 - wait
@@ -50,7 +57,7 @@ steps:
 # run the tests
 - group: test
   steps:
-    - label: ghc{{matrix}}
-      command: nix build -L .#checks.x86_64-linux.ghc${{ matrix }}:test-all --keep-going
+    - label: {{matrix}}
+      command: nix build -L .#checks.x86_64-linux.${{ matrix }}:test-all --keep-going
 
-      matrix: *ghc-matrix
+      matrix: *build-matrix

--- a/haskell.nix/library/.github/workflows/check.yml
+++ b/haskell.nix/library/.github/workflows/check.yml
@@ -43,9 +43,9 @@ jobs:
       #   run: nix build -L .#checks.x86_64-linux.shellcheck
       #   if: success() || failure()
 
-  # Export JSON serialized ghc-versions
-  # For this to work, you must uncomment ghc-matrix in flake.nix
-  ghc-versions:
+  # Export JSON serialized check prefixes
+  # For this to work, you must uncomment inherit (ci) build-matrix in flake.nix
+  check-prefixes:
     runs-on: [self-hosted, nix]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -53,22 +53,22 @@ jobs:
     - uses: actions/checkout@v3
 
     - id: set-matrix
-      run: echo "matrix=$(nix eval --json .#ghc-matrix.x86_64-linux)" >> $GITHUB_OUTPUT
+      run: echo "matrix=$(nix eval --json .#build-matrix.x86_64-linux)" >> $GITHUB_OUTPUT
 
   build-and-test:
-    needs: ghc-versions
-    name: ghc${{ matrix.ghc }}
+    needs: check-prefixes
+    name: ${{ matrix.prefix }}
     runs-on: [self-hosted, nix]
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.ghc-versions.outputs.matrix)}}
+      matrix: ${{fromJson(needs.check-prefixes.outputs.matrix)}}
 
     steps:
       - uses: actions/checkout@v3
 
       - name: build
-        run: nix build -L .#checks.x86_64-linux.${{ matrix.ghc }}:build-all --keep-going
+        run: nix build -L .#checks.x86_64-linux.${{ matrix.prefix }}:build-all --keep-going
 
       - name: test
-        run: nix build -L .#checks.x86_64-linux.${{ matrix.ghc }}:test-all --keep-going
+        run: nix build -L .#checks.x86_64-linux.${{ matrix.prefix }}:test-all --keep-going
         if: success() || failure()


### PR DESCRIPTION
Problem: Our CI template for libraries allows one to specify ghc-versions so that we can build a library in different configurations. Currently the only configurable thing is the GHC version. To do this, we have developed a wrapper over haskell.nix and want to update our library template to use it.

Solution: Modify our library template to use the `makeCI` wrapper.