### PR TITLE
[OPS-1454] Add `cabal outdated` check

### DIFF
--- a/haskell.nix/README.md
+++ b/haskell.nix/README.md
@@ -21,7 +21,9 @@ Haskell application and library templates for Buildkite, Gitlab or GitHub CI usi
 
     3. If you're using `hpack` or `stack2cabal` in your project, make sure to uncomment the related lines in both `flake.nix` and pipeline configuration files. To avoid version mismatches, use `nix develop .#ci -c hpack` or `nix develop .#ci -c stack2cabal`.
 
-    4. Make sure to clean up your `flake.nix` and pipeline configuration files by removing any optional code that is left commented out.
+    4. You may want to add scheduled `cabal outdated` checks to be notified of new dependency versions. To do this for a GitHub repository, copy `.github/workflows/check-outdated.yml` to your library repository, and for a Gitlab repository, uncomment `check-outdated` and `report-outdated` in `.gitlab-ci.yml` and configure the schedule in the repository settings. In both cases, you need to provide the `SLACK_TOKEN` to the CI environment.
+
+    5. Make sure to clean up your `flake.nix` and pipeline configuration files by removing any optional code that is left commented out.
 
 - Enjoy working CI!
 

--- a/haskell.nix/library/.github/workflows/check-outdated.yml
+++ b/haskell.nix/library/.github/workflows/check-outdated.yml
@@ -1,0 +1,44 @@
+on:
+  schedule:
+    # runs every Monday at 10:00 am UTC
+    - cron: '0 10 * * 1'
+
+jobs:
+  check-outdated:
+    runs-on: [self-hosted, nix]
+    outputs:
+      msg: ${{ steps.outdated.outputs.outdated }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check outdated packages
+        id: outdated
+        run: |
+          function output {
+            echo "outdated<<EOF" >> $GITHUB_OUTPUT
+            echo "Repository https://github.com/${{ github.repository }} has outdated haskell dependencies" >> $GITHUB_OUTPUT
+            echo "$msg" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          }
+
+          nix develop .#ci -c cabal update
+          trap 'output' ERR
+          msg=$(nix develop .#ci -c cabal outdated --exit-code)
+
+  report-outdated:
+    runs-on: [self-hosted, nix]
+    if: failure()
+    needs: check-outdated
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Report outdated haskell dependencies
+        env:
+          MSG: ${{needs.check-outdated.outputs.msg}}
+        run: |
+          # you can change 'libraries' to the channel dedicated to the library, if there is one
+          # in order for a bot to be able to post messages, it must be added to the appropriate channel
+          nix develop .#ci -c curl -XPOST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${{ env.SLACK_TOKEN }}" \
+            -d "channel=libraries" \
+            -d "text=$MSG"

--- a/haskell.nix/library/.gitlab-ci.yml
+++ b/haskell.nix/library/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - validate
   - build
   - test
+  - cabal-outdated
 
 xrefcheck:
   stage: validate
@@ -69,3 +70,34 @@ test:
   script:
     - nix build -L .#checks.x86_64-linux.ghc$GHC:test-all --keep-going
   parallel: *ghc-matrix
+
+# uncomment to run scheduled `cabal outdated` check, in order for it to work you will need to set a schedule in the gitlab repository settings
+# check-outdated:
+#   stage: cabal-outdated
+#   script:
+#     - function output {
+#         echo "Repository https://gitlab.com/$CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME has outdated dependencies" > msg.txt;
+#         echo "$msg" >> msg.txt;
+#       }
+#     - nix develop .#ci -c cabal update
+#     - trap 'output' ERR
+#     - msg=$(nix develop .#ci -c cabal outdated --exit-code)
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#   artifacts:
+#     when: on_failure
+#     paths:
+#       - msg.txt
+
+# report-outdated:
+#   stage: cabal-outdated
+#   script:
+#     # you can change 'libraries' to the channel dedicated to the library, if there is one
+#     # in order for a bot to be able to post messages, it must be added to the appropriate channel
+#     - 'nix develop .#ci -c curl -XPOST https://slack.com/api/chat.postMessage -H "Authorization: Bearer $SLACK_TOKEN" -d "channel=libraries" -d "text=$(cat ./msg.txt)"'
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == "schedule"
+#   when: on_failure
+#   needs:
+#     - job: check-outdated
+#       artifacts: true

--- a/haskell.nix/library/flake.nix
+++ b/haskell.nix/library/flake.nix
@@ -70,16 +70,22 @@
         # Uncomment if your project uses GitHub actions
         # inherit (ci) build-matrix;
 
-        # Uncomment if your project uses hpack or stack2cabal to update cabal files, remove the one you don't use
+        devShell = {
+          ci = pkgs.mkShell {
+            buildInputs = [
+              # Uncomment if your project uses hpack or stack2cabal to update cabal files, remove the one you don't use
         # To avoid version mismatches, use `nix develop .#ci -c hpack` or `nix develop .#ci -c stack2cabal`
-        # devShell = {
-        #   ci = pkgs.mkShell {
-        #     buildInputs = [
-        #       pkgs.hpack
-        #       stack2cabal
-        #     ];
-        #   };
-        # };
+              # pkgs.hpack
+              # stack2cabal
+
+              # Uncomment if your project uses scheduled pipeline for `cabal outdated` check
+              # pkgs.cabal-install
+              # pkgs.curl
+              # # GHC is required for `cabal outdated`
+              # pkgs.ghc
+            ];
+          };
+        };
 
         # derivations that we can run from CI
         checks = ci.build-all // ci.test-all // {


### PR DESCRIPTION
Problem: We want to be able to be notified when our libraries contain outdated dependencies.

Solution: Add scheduled `cabal outdated` check to github and gitlab CI pipelines.