### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/haskell.nix/application/.github/workflows/check.yml
+++ b/haskell.nix/application/.github/workflows/check.yml
@@ -5,7 +5,7 @@ jobs:
   validate:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: xrefcheck
         run: nix run github:serokell/xrefcheck
@@ -42,7 +42,7 @@ jobs:
   build:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: build-all
         run: nix build -L .#checks.x86_64-linux.build-all --keep-going
@@ -51,7 +51,7 @@ jobs:
     runs-on: [self-hosted, nix]
     needs: [build]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: test
         run: nix build -L .#checks.x86_64-linux.test

--- a/haskell.nix/library/.github/workflows/check.yml
+++ b/haskell.nix/library/.github/workflows/check.yml
@@ -5,7 +5,7 @@ jobs:
   validate:
     runs-on: [self-hosted, nix]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: xrefcheck
         run: nix run github:serokell/xrefcheck
@@ -50,7 +50,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - id: set-matrix
       run: echo "matrix=$(nix eval --json .#build-matrix.x86_64-linux)" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
       matrix: ${{fromJson(needs.check-prefixes.outputs.matrix)}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: build
         run: nix build -L .#checks.x86_64-linux.${{ matrix.prefix }}:build-all --keep-going


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs
no longer supports this runtime. However, "actions/checkout@v3" uses
this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".
