### PR TITLE
[OPS-1531] Update GA pipeline trigger condition to be suitable for forks

### DIFF
--- a/haskell.nix/application/.github/workflows/check.yml
+++ b/haskell.nix/application/.github/workflows/check.yml
@@ -1,5 +1,10 @@
 name: Nix flake check
-on: push
+on:
+  pull_request:
+  push:
+    # If your is default branch is 'main' delete the next line and uncomment the line following it
+    branches: master
+    # branches: main
 
 jobs:
   validate:

--- a/haskell.nix/library/.github/workflows/check.yml
+++ b/haskell.nix/library/.github/workflows/check.yml
@@ -1,5 +1,11 @@
 name: Nix flake check
-on: push
+on:
+  pull_request:
+  push:
+    # If your is default branch is 'main' delete the next line and uncomment the line following it
+    branches: master
+    # branches: main
+
 
 jobs:
   validate:


### PR DESCRIPTION
Problem: Currently, GA pipeline is only triggered by pushes to branches within the repo. As a result, CI is never triggered for PRs from forks.

Solution: Use 'on: pull_request:' to allow running CI on PRs from forks. Use 'on: push: branches: master' to run the pipeline on the default branch to ensure that checks pass.